### PR TITLE
[cm] Saving wrapper model earlier and export flags

### DIFF
--- a/neutone_sdk/core.py
+++ b/neutone_sdk/core.py
@@ -54,6 +54,11 @@ class NeutoneModel(ABC, nn.Module):
         work).
         """
         super().__init__()
+
+        # Save and prepare model
+        model.eval()
+        self.model = model
+
         self.MAX_N_PARAMS = self._get_max_n_params()
         self.SDK_VERSION = constants.SDK_VERSION
         self.CURRENT_TIME = time.time()
@@ -102,10 +107,6 @@ class NeutoneModel(ABC, nn.Module):
         self.neutone_parameter_types = [
             p.type.value for p in self.get_neutone_parameters()
         ]
-
-        # Save and prepare model
-        model.eval()
-        self.model = model
 
     @abstractmethod
     def _get_max_n_params(self) -> int:

--- a/neutone_sdk/core.py
+++ b/neutone_sdk/core.py
@@ -55,7 +55,8 @@ class NeutoneModel(ABC, nn.Module):
         """
         super().__init__()
 
-        # Save and prepare model
+        # Save and prepare model. This should be done at the very beginning of the
+        # constructor to enable accessing the model in other methods of this class.
         model.eval()
         self.model = model
 

--- a/neutone_sdk/utils.py
+++ b/neutone_sdk/utils.py
@@ -68,6 +68,7 @@ def save_neutone_model(
     freeze: bool = False,
     optimize: bool = False,
     speed_benchmark: bool = True,
+    test_offline_mode: bool = True,
 ) -> None:
     """
     Save a Neutone model to disk as a Torchscript file. Additionally include metadata file and samples as needed.
@@ -87,6 +88,7 @@ def save_neutone_model(
         optimize: If true, jit.optimize_for_inference will be applied to the model.
         speed_benchmark: If true, will run a speed benchmark when submission is also true.
                 Consider disabling for non-realtime models as it might take too long.
+        test_offline_mode: If true, will run an offline mode test. Must be true if submission is true.
 
     Returns:
       Will create the following files:
@@ -97,6 +99,12 @@ def save_neutone_model(
         root_dir/samples/*
       ```
     """
+    if submission:
+        assert dump_samples, "If submission is True then dump_samples must also be True"
+        assert (
+            test_offline_mode
+        ), "If submission is True then test_offline_mode must also be True"
+
     random.seed(0)
     tr.manual_seed(0)
     if not model.use_debug_mode:
@@ -132,19 +140,23 @@ def save_neutone_model(
         with open(root_dir / "metadata.json", "w") as f:
             json.dump(metadata, f, indent=4)
 
-        log.info("Running model on audio samples...")
-        if audio_sample_pairs is None:
-            input_samples = get_default_audio_samples()
-            audio_sample_pairs = []
-            for input_sample in input_samples:
-                rendered_sample = render_audio_sample(sqw, input_sample)
-                audio_sample_pairs.append(
-                    AudioSamplePair(input_sample, rendered_sample)
-                )
+        if dump_samples:
+            log.info("Running model on audio samples...")
+            if audio_sample_pairs is None:
+                input_samples = get_default_audio_samples()
+                audio_sample_pairs = []
+                for input_sample in input_samples:
+                    rendered_sample = render_audio_sample(sqw, input_sample)
+                    audio_sample_pairs.append(
+                        AudioSamplePair(input_sample, rendered_sample)
+                    )
 
-        metadata["sample_sound_files"] = [
-            pair.to_metadata_format() for pair in audio_sample_pairs[:max_n_samples]
-        ]
+            metadata["sample_sound_files"] = [
+                pair.to_metadata_format() for pair in audio_sample_pairs[:max_n_samples]
+            ]
+        else:
+            metadata["sample_sound_files"] = []
+
         log.info("Validating metadata...")
         validate_metadata(metadata)
         extra_files = {"metadata.json": json.dumps(metadata, indent=4).encode("utf-8")}
@@ -166,14 +178,17 @@ def save_neutone_model(
         loaded_model.reset()
         loaded_model.is_resampling()
 
-        log.info("Testing offline mode...")
-        for input_sample in get_default_audio_samples():
-            offline_sr = input_sample.sr
-            offline_bs = 4096
-            loaded_model.set_daw_sample_rate_and_buffer_size(offline_sr, offline_bs)
-            offline_params = tr.rand((MAX_N_PARAMS, input_sample.audio.size(1)))
-            offline_rendered_sample = loaded_model.forward_offline(input_sample.audio, offline_params)
-            break  # Only test one sample to reduce export time
+        if test_offline_mode:
+            log.info("Testing offline mode...")
+            for input_sample in get_default_audio_samples():
+                offline_sr = input_sample.sr
+                offline_bs = 4096
+                loaded_model.set_daw_sample_rate_and_buffer_size(offline_sr, offline_bs)
+                offline_params = tr.rand((MAX_N_PARAMS, input_sample.audio.size(1)))
+                offline_rendered_sample = loaded_model.forward_offline(
+                    input_sample.audio, offline_params
+                )
+                break  # Only test one sample to reduce export time
 
         if submission:  # Do extra checks
             log.info("Running submission checks...")


### PR DESCRIPTION
This PR moves saving the internal model in the neutone wrapper to the very beginning before calling the superclass constructor so that one can call `self.model.attribute_name` in some of the other methods of the wrapper without causing an exception.

It also adds an additional flag to the export method to speed things up when prototyping.