### PR TITLE
[cm]  Removing LongTensor typing

### DIFF
--- a/examples/neutone_gen/example_musicgen_load.py
+++ b/examples/neutone_gen/example_musicgen_load.py
@@ -1,13 +1,19 @@
-import logging, os, argparse, pathlib, json
+import argparse
+import json
+import logging
+import os
+from typing import List, Dict
+
 import torch
-import torch.nn as nn
-from typing import List, Tuple, Dict
-
-from neutone_sdk.non_realtime_wrapper import NonRealtimeTokenizerBase
-from neutone_sdk import NeutoneParameter, DiscreteTokensNeutoneParameter, ContinuousNeutoneParameter
-from neutone_sdk.non_realtime_sqw import NonRealtimeSampleQueueWrapper
-
 import torchaudio
+
+from neutone_sdk import (
+    NeutoneParameter,
+    DiscreteTokensNeutoneParameter,
+    ContinuousNeutoneParameter,
+)
+from neutone_sdk.non_realtime_sqw import NonRealtimeSampleQueueWrapper
+from neutone_sdk.non_realtime_wrapper import NonRealtimeTokenizerBase
 
 logging.basicConfig()
 log = logging.getLogger(__name__)
@@ -134,9 +140,20 @@ class NonRealtimeMusicGenModelWrapper(NonRealtimeTokenizerBase):
             DiscreteTokensNeutoneParameter(
                 "texttokens",
                 "tokens from a text tokenizer",
-                default_value=torch.LongTensor(
-                    [[2775, 7, 2783, 1463, 28, 7981, 63, 5253, 7, 11, 13353, 1]]
-                ),
+                default_value=[
+                    2775,
+                    7,
+                    2783,
+                    1463,
+                    28,
+                    7981,
+                    63,
+                    5253,
+                    7,
+                    11,
+                    13353,
+                    1,
+                ],
             ),
             ContinuousNeutoneParameter(
                 "outputlength", "number of output tokens", default_value=0.5
@@ -172,11 +189,14 @@ class NonRealtimeMusicGenModelWrapper(NonRealtimeTokenizerBase):
         audio_in: List[torch.Tensor],
         knob_params: Dict[str, torch.Tensor],
         text_params: List[str],
-        tokens_params: List[torch.Tensor],
+        tokens_params: List[List[int]],
     ) -> List[torch.Tensor]:
         audio_out = []
         output_length = int(knob_params["outputlength"].mean() * 500)
-        x = self.model.forward(tokens_params[0], output_length)
+        tokens = tokens_params[0]
+        # Convert to LongTensor with batch size of 1
+        tokens = torch.LongTensor(tokens).unsqueeze(0)
+        x = self.model.forward(tokens, output_length)
         audio_out.append(x.squeeze(1))
         return audio_out
         # return [self.model.forward(min_val, min_val, max_val, gain)]
@@ -189,8 +209,8 @@ if __name__ == "__main__":
     parser.add_argument("--model", default="musicgen-model", type=str)
     args = parser.parse_args()
 
-    model = torch.jit.load(pathlib.Path(args.model) / "musicgen_scripted_notok.ts")
-    tok_path = str(pathlib.Path(args.model) / "tokenizer.json")
+    model = torch.jit.load("../../out/musicgen_scripted_notok.ts")
+    tok_path = str("../../out/tokenizer.json")
     tokenizer = Tokenizer.from_file(tok_path)
     with open(tok_path, "r", encoding="utf-8") as f:
         json_string = json.dumps(json.load(f), ensure_ascii=True)
@@ -201,29 +221,24 @@ if __name__ == "__main__":
     out = sqw.forward_non_realtime(
         [],
         torch.ones(1, 2048) * 0.2,
-        tokens_params=[
-            # "80s pop track with bassy drums and synth"
-            # torch.LongTensor(
-            #     [[2775, 7, 2783, 1463, 28, 7981, 63, 5253, 7, 11, 13353, 1]]
-            # )
-            torch.LongTensor([tokens])
-        ],
+        tokens_params=[tokens],
     )
     sqw.reset()
     sqw.prepare_for_inference()
     log.info(f"   out[0].shape: {out[0].shape}")
     log.info(f"   out: {out}")
     ts = torch.jit.script(sqw)
+    log.info(f"Scripting successful")
     n_samples = 2048
     tokens = tokenizer.encode("90s rock song with loud guitars and heavy drums").ids
     out_ts = ts.forward_non_realtime(
         [],
         torch.ones(1, 2048) * 0.2,
-        tokens_params=[torch.LongTensor([tokens])],
+        tokens_params=[tokens],
     )
     log.info(f"out_ts[0].shape: {out_ts[0].shape}")
     log.info(f"out_ts: {out_ts}")
-    torchaudio.save("out_ts.wav", out_ts[0], sample_rate=32000)
-    torch.jit.save(ts, pathlib.Path(args.model) / "wrapped-musicgen.ts")
-    model = torch.jit.load(pathlib.Path(args.model) / "wrapped-musicgen.ts")
+    torchaudio.save("../../out/out_ts.wav", out_ts[0], sample_rate=32000)
+    torch.jit.save(ts, "../../out/wrapped-musicgen.ts")
+    model = torch.jit.load("../../out/wrapped-musicgen.ts")
     print(model.get_tokenizer_json())

--- a/neutone_sdk/core.py
+++ b/neutone_sdk/core.py
@@ -234,7 +234,7 @@ class NeutoneModel(ABC, nn.Module):
     @tr.jit.export
     def get_neutone_parameters_metadata(
         self,
-    ) -> Dict[str, Dict[str, Union[int, float, str, bool, List[str], Tensor]]]:
+    ) -> Dict[str, Dict[str, Union[int, float, str, bool, List[str], List[int]]]]:
         """
         Returns the metadata of the parameters as a dictionary of ParameterMetadata
         named tuples.

--- a/neutone_sdk/non_realtime_sqw.py
+++ b/neutone_sdk/non_realtime_sqw.py
@@ -158,7 +158,7 @@ class NonRealtimeSampleQueueWrapper(nn.Module):
         audio_in: List[Tensor],
         numerical_params: Optional[Tensor] = None,
         text_params: Optional[List[str]] = None,
-        tokens_params: Optional[List[Tensor]] = None,
+        tokens_params: Optional[List[List[int]]] = None,
     ) -> List[Tensor]:
         return self.forward_non_realtime(
             audio_in, numerical_params, text_params, tokens_params
@@ -170,7 +170,7 @@ class NonRealtimeSampleQueueWrapper(nn.Module):
         audio_in: List[Tensor],
         numerical_params: Optional[Tensor] = None,
         text_params: Optional[List[str]] = None,
-        tokens_params: Optional[List[Tensor]] = None,
+        tokens_params: Optional[List[List[int]]] = None,
     ) -> List[Tensor]:
         # TODO(cm): this is a workaround for the C++ plugin inputting empty audio
         # tensors instead of an empty list
@@ -180,6 +180,8 @@ class NonRealtimeSampleQueueWrapper(nn.Module):
             numerical_params = None
         if self.nrb.n_text_params == 0:
             text_params = None
+        if self.nrb.n_tokens_params == 0:
+            tokens_params = None
 
         if self.use_debug_mode:
             assert len(audio_in) == self.n_in_tracks

--- a/neutone_sdk/non_realtime_wrapper.py
+++ b/neutone_sdk/non_realtime_wrapper.py
@@ -5,7 +5,7 @@ from abc import abstractmethod
 from typing import Dict, List, Optional, Tuple, Union, Any
 
 import torch as tr
-from torch import Tensor, nn, LongTensor
+from torch import Tensor, nn
 
 from neutone_sdk import (
     NeutoneModel,
@@ -32,7 +32,7 @@ class NonRealtimeBase(NeutoneModel):
     # (https://github.com/pytorch/pytorch/issues/51041#issuecomment-767061194)
     # From NeutoneModel, sometimes TorchScript complains if there are not redefined here
     neutone_parameters_metadata: Dict[
-        str, Dict[str, Union[int, float, str, bool, List[str], LongTensor]]
+        str, Dict[str, Union[int, float, str, bool, List[str], List[int]]]
     ]
     remapped_params: Dict[str, Tensor]
     neutone_parameter_names: List[str]
@@ -45,7 +45,7 @@ class NonRealtimeBase(NeutoneModel):
     text_param_max_n_chars: List[int]
     text_param_default_values: List[str]
     tokens_param_max_n_tokens: List[int]
-    tokens_param_default_values: List[LongTensor]
+    tokens_param_default_values: List[List[int]]
 
     def __init__(self, model: nn.Module, use_debug_mode: bool = True) -> None:
         """
@@ -156,27 +156,8 @@ class NonRealtimeBase(NeutoneModel):
                 self.get_audio_out_channels()
             ), "No. of output audio labels must match no. of output audio channels"
 
-        # Save metadata JSON
-        metadata = self.to_metadata()
-
-        def convert_longtensors_to_lists(data_structure):
-            if isinstance(data_structure, dict):
-                new_dict = {}
-                for key, value in data_structure.items():
-                    new_dict[key] = convert_longtensors_to_lists(value)
-                return new_dict
-            elif isinstance(data_structure, list):
-                new_list = []
-                for item in data_structure:
-                    new_list.append(convert_longtensors_to_lists(item))
-                return new_list
-            elif isinstance(data_structure, tr.LongTensor):
-                return data_structure.tolist()
-            else:
-                return data_structure
-
         self.metadata_json_str = json.dumps(
-            convert_longtensors_to_lists(metadata), indent=4, sort_keys=True
+            self.to_metadata(), indent=4, sort_keys=True
         )
 
     def _get_max_n_params(self) -> int:
@@ -268,7 +249,7 @@ class NonRealtimeBase(NeutoneModel):
         audio_in: List[Tensor],
         cont_params: Dict[str, Tensor],
         text_params: List[str],
-        tokens_params: List[LongTensor],
+        tokens_params: List[List[int]],
     ) -> List[Tensor]:
         """
         SDK users can overwrite this method to implement the logic for their models.
@@ -295,7 +276,7 @@ class NonRealtimeBase(NeutoneModel):
                 List of strings containing the text parameters. Will be empty if the
                 model does not have any text parameters.
             tokens_params:
-                List of long tensors containing the tokens. Will be empty if the
+                List of list of ints containing the tokens. Will be empty if the
                 model does not have any tokens parameters.
 
         Returns:
@@ -397,7 +378,7 @@ class NonRealtimeBase(NeutoneModel):
         audio_in: List[Tensor],
         numerical_params: Optional[Tensor] = None,
         text_params: Optional[List[str]] = None,
-        tokens_params: Optional[List[LongTensor]] = None,
+        tokens_params: Optional[List[List[int]]] = None,
     ) -> List[Tensor]:
         """
         Internal forward pass for a NonRealtimeBase wrapped model.
@@ -431,8 +412,8 @@ class NonRealtimeBase(NeutoneModel):
                 ):
                     if max_n_tokens != -1:
                         assert (
-                            tokens.shape[-1] <= max_n_tokens
-                        ), f"Input tokens must be shorter than {max_n_tokens} characters"
+                            len(tokens) <= max_n_tokens
+                        ), f"Input tokens must be shorter than {max_n_tokens}"
 
         in_n = self.current_model_buffer_size
         if numerical_params is not None:

--- a/neutone_sdk/parameter.py
+++ b/neutone_sdk/parameter.py
@@ -4,8 +4,6 @@ from abc import ABC
 from enum import Enum
 from typing import Union, Optional, List, Dict
 
-import torch
-
 from neutone_sdk import constants
 
 logging.basicConfig()
@@ -32,7 +30,7 @@ class NeutoneParameter(ABC):
         self,
         name: str,
         description: str,
-        default_value: Union[int, float, str],
+        default_value: Union[int, float, str, Optional[List[int]]],
         used: bool,
         param_type: NeutoneParameterType,
     ):
@@ -42,7 +40,9 @@ class NeutoneParameter(ABC):
         self.used = used
         self.type = param_type
 
-    def to_metadata(self) -> Dict[str, Union[int, float, str, bool, List[str]]]:
+    def to_metadata(
+        self,
+    ) -> Dict[str, Union[int, float, str, bool, List[str], List[int]]]:
         return {
             "name": self.name,
             "description": self.description,
@@ -122,7 +122,9 @@ class CategoricalNeutoneParameter(NeutoneParameter):
         self.labels = labels
 
     # def to_metadata(self) -> ParameterMetadata:
-    def to_metadata(self) -> Dict[str, Union[int, float, str, bool, List[str]]]:
+    def to_metadata(
+        self,
+    ) -> Dict[str, Union[int, float, str, bool, List[str], List[int]]]:
         metadata = super().to_metadata()
         metadata["n_values"] = self.n_values
         metadata["labels"] = self.labels
@@ -158,7 +160,9 @@ class TextNeutoneParameter(NeutoneParameter):
             ), "`default_value` must be a string of length less than `max_n_chars`"
         self.max_n_chars = max_n_chars
 
-    def to_metadata(self) -> Dict[str, Union[int, float, str, bool, List[str]]]:
+    def to_metadata(
+        self,
+    ) -> Dict[str, Union[int, float, str, bool, List[str], List[int]]]:
         metadata = super().to_metadata()
         metadata["max_n_chars"] = self.max_n_chars
         return metadata
@@ -178,22 +182,24 @@ class DiscreteTokensNeutoneParameter(NeutoneParameter):
         name: str,
         description: str,
         max_n_tokens: int = -1,
-        default_value: Optional[torch.LongTensor] = None,
+        default_value: Optional[List[int]] = None,
         used: bool = True,
     ):
+        if default_value is None:
+            default_value: List[int] = []
         super().__init__(
             name, description, default_value, used, NeutoneParameterType.TOKENS
         )
         assert max_n_tokens >= -1, "`max_n_tokens` must be greater than or equal to -1"
         if max_n_tokens != -1:
             assert (
-                default_value.shape[-1] <= max_n_tokens
-            ), "`default_value` must be a string of length less than `max_n_tokens`"
+                len(default_value) <= max_n_tokens
+            ), "`default_value` must be a list of length less than `max_n_tokens`"
         self.max_n_tokens = max_n_tokens
 
     def to_metadata(
         self,
-    ) -> Dict[str, Union[int, float, str, bool, List[str], Optional[torch.LongTensor]]]:
+    ) -> Dict[str, Union[int, float, str, bool, List[str], List[int]]]:
         metadata = super().to_metadata()
         metadata["max_n_tokens"] = self.max_n_tokens
         return metadata


### PR DESCRIPTION
This PR makes the typing in the SDK for `tokens_params` simpler by using List[int] instead of LongTensor.
