### PR TITLE
[nm] has_progress_percentage for one shot models

### DIFF
--- a/examples/neutone_gen/example_musicgen_load.py
+++ b/examples/neutone_gen/example_musicgen_load.py
@@ -188,6 +188,10 @@ class NonRealtimeMusicGenModelWrapper(NonRealtimeTokenizerBase):
     def is_one_shot_model(self) -> bool:
         return True
 
+    @torch.jit.export
+    def has_progress_percentage(self) -> bool:
+        return True
+
     def aggregate_continuous_params(self, cont_params: torch.Tensor) -> torch.Tensor:
         return cont_params  # We want sample-level control, so no aggregation
 

--- a/examples/neutone_gen/example_musicgen_load.py
+++ b/examples/neutone_gen/example_musicgen_load.py
@@ -204,7 +204,22 @@ class NonRealtimeMusicGenModelWrapper(NonRealtimeTokenizerBase):
         tokens = tokens_params[0]
         # Convert to LongTensor with batch size of 1
         tokens = torch.LongTensor(tokens).unsqueeze(0)
-        x = self.model.forward(tokens, output_length)
+        with torch.no_grad():
+            input_ids, encoder_outputs, delay_pattern_mask, encoder_attention_mask = (
+                self.model.preprocess(tokens, output_length)
+            )
+            for i in range(output_length - 1):
+                input_ids = self.model.sample_step(
+                    input_ids,
+                    encoder_outputs,
+                    delay_pattern_mask,
+                    encoder_attention_mask,
+                )
+                self.set_progress_percentage(float(i + 1) / output_length * 100)
+                if self.should_cancel_forward_pass():
+                    # Can't return empty list for some reason
+                    break
+            x = self.model.postprocess(input_ids, delay_pattern_mask, tokens)
         audio_out.append(x.squeeze(1))
         return audio_out
         # return [self.model.forward(min_val, min_val, max_val, gain)]

--- a/neutone_sdk/non_realtime_sqw.py
+++ b/neutone_sdk/non_realtime_sqw.py
@@ -445,6 +445,10 @@ class NonRealtimeSampleQueueWrapper(nn.Module):
         return total_prog_percentage
 
     @tr.jit.export
+    def has_progress_percentage(self) -> bool:
+        return self.nrb.has_progress_percentage()
+
+    @tr.jit.export
     def should_cancel_forward_pass(self) -> bool:
         return self.nrb.should_cancel_forward_pass()
 
@@ -490,6 +494,7 @@ class NonRealtimeSampleQueueWrapper(nn.Module):
             "set_daw_sample_rate_and_buffer_size",
             "is_one_shot_model",
             "get_progress_percentage",
+            "has_progress_percentage",
             "should_cancel_forward_pass",
             "request_cancel_forward_pass",
             "is_text_model",

--- a/neutone_sdk/non_realtime_wrapper.py
+++ b/neutone_sdk/non_realtime_wrapper.py
@@ -329,11 +329,11 @@ class NonRealtimeBase(NeutoneModel):
 
     def has_progress_percentage(self) -> bool:
         """
-        Return True if the model sets the progress percentage of the model during
+        Returns True if the model sets the progress percentage of the model during
         forward pass.
-        If this is False, the plugin should estimate the progress based on last run.
+        If this is False and the model is a oneshot model, the plugin should estimate the progress based on last run.
         """
-        return False
+        return True
 
     def get_audio_in_labels(self) -> List[str]:
         """

--- a/neutone_sdk/non_realtime_wrapper.py
+++ b/neutone_sdk/non_realtime_wrapper.py
@@ -327,6 +327,14 @@ class NonRealtimeBase(NeutoneModel):
             ), "Progress percentage must be between 0 and 100"
         self.progress_percentage = progress_percentage
 
+    def has_progress_percentage(self) -> bool:
+        """
+        Return True if the model sets the progress percentage of the model during
+        forward pass.
+        If this is False, the plugin should estimate the progress based on last run.
+        """
+        return False
+
     def get_audio_in_labels(self) -> List[str]:
         """
         Returns the labels for the input audio channels which will be displayed in the
@@ -583,6 +591,7 @@ class NonRealtimeBase(NeutoneModel):
                 "set_sample_rate_and_buffer_size",
                 "reset",
                 "get_progress_percentage",
+                "has_progress_percentage",
                 "should_cancel_forward_pass",
                 "request_cancel_forward_pass",
                 "is_text_model",


### PR DESCRIPTION
It seems some one-shot models like loopgan and maybe diffusion won't be able to set_progress_percentage and the progress would be stuck at 0.
This PR adds has_progress_percentage so when it's false and the model is a one-shot model the plugin can fall back to using time it took for the last run to provide a progress bar.
Also the musicgen example now sets progress percentage.